### PR TITLE
De-dupe messages to sender (#9)

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,9 +5,9 @@ Allows you to send out mass text messages to a list of subscribers.
 ### Installation
 
 1) Download zip of the repository.
-2) Run `composer install`
-3) Create a database
-4) Run `database.sql` on the database.
+2) Run `composer install` from inside the target dir
+3) Create a database `sub`
+4) Run `database.sql` on the `sub` database.
 5) Add the connection info for the database in `config.php`.
 6) Set up a twilio account.
 7) Add the twilio info in `config.php`.

--- a/subscribe.php
+++ b/subscribe.php
@@ -41,7 +41,8 @@ if (trim(strtoupper($body)) == strtoupper($subscribe_keyword)) {
     $found = $db->single();
 
     if ($found && count($found) == 1) {
-        $db->query("SELECT `contact` FROM `subscribers`");
+        $db->query("SELECT `contact` FROM `subscribers` WHERE `contact` != :contact");
+        $db->bind(":contact", $contact);
         $contacts = $db->resultset();
 
         $message = preg_replace("/BROADCAST/i", " ", $body);
@@ -70,7 +71,7 @@ if (trim(strtoupper($body)) == strtoupper($subscribe_keyword)) {
             $GLOBALS['twilioClient']->messages->create($contact_number, $payload);
         }
     } else {
-        $message = "denied";
+        $message = "You are not allowed to broadcast to this list.";
     }
     $db->close();
 } else {


### PR DESCRIPTION
* De-dupe messages to sender

Removes sender from payload array so they do not receive message twice.

* Switching from PHP exclusion to mysql exclusion

Fixed whitespace/EOF  issues too to meet project's standards

* Fixed Whitespace